### PR TITLE
Advanced storage

### DIFF
--- a/rust/agama-lib/src/storage/client.rs
+++ b/rust/agama-lib/src/storage/client.rs
@@ -147,6 +147,14 @@ impl<'a> StorageClient<'a> {
             .await?)
     }
 
+    /// Set the storage config according to the JSON schema
+    pub async fn set_incremental_config(&self, settings: StorageSettings) -> Result<u32, ServiceError> {
+        Ok(self
+            .storage_proxy
+            .set_incremental_config(serde_json::to_string(&settings).unwrap().as_str())
+            .await?)
+    }
+
     /// Get the storage config according to the JSON schema
     pub async fn get_config(&self) -> Result<StorageSettings, ServiceError> {
         let serialized_settings = self.storage_proxy.get_config().await?;

--- a/rust/agama-lib/src/storage/proxies.rs
+++ b/rust/agama-lib/src/storage/proxies.rs
@@ -41,6 +41,9 @@ trait Storage1 {
     /// Set the storage config according to the JSON schema
     fn set_config(&self, settings: &str) -> zbus::Result<u32>;
 
+    /// Set the storage config according to the JSON schema
+    fn set_incremental_config(&self, settings: &str) -> zbus::Result<u32>;
+
     /// Get the current storage config according to the JSON schema
     fn get_config(&self) -> zbus::Result<String>;
 

--- a/service/lib/agama/dbus/storage/manager.rb
+++ b/service/lib/agama/dbus/storage/manager.rb
@@ -103,11 +103,11 @@ module Agama
         #
         # @param serialized_config [String] Serialized storage config.
         # @return [Integer] 0 success; 1 error
-        def apply_config(serialized_config)
+        def apply_config(serialized_config, incremental: false)
           logger.info("Setting storage config from D-Bus: #{serialized_config}")
 
           config_json = JSON.parse(serialized_config, symbolize_names: true)
-          proposal.calculate_from_json(config_json)
+          proposal.calculate_from_json(config_json, incremental: incremental)
           proposal.success? ? 0 : 1
         end
 
@@ -146,6 +146,9 @@ module Agama
           dbus_method(:Probe) { probe }
           dbus_method(:SetConfig, "in serialized_config:s, out result:u") do |serialized_config|
             busy_while { apply_config(serialized_config) }
+          end
+          dbus_method(:SetIncrementalConfig, "in serialized_config:s, out result:u") do |serialized_config|
+            busy_while { apply_config(serialized_config, incremental: true) }
           end
           dbus_method(:GetConfig, "out serialized_config:s") { recover_config }
           dbus_method(:GetConfigModel, "out serialized_model:s") { recover_model }

--- a/service/lib/agama/storage/proposal_strategies/agama.rb
+++ b/service/lib/agama/storage/proposal_strategies/agama.rb
@@ -44,8 +44,8 @@ module Agama
         end
 
         # @see Base#calculate
-        def calculate
-          @proposal = agama_proposal
+        def calculate(devicegraph: nil)
+          @proposal = agama_proposal(devicegraph: devicegraph)
           @proposal.propose
         ensure
           storage_manager.proposal = @proposal
@@ -66,11 +66,10 @@ module Agama
         # Instance of the Y2Storage proposal to be used to run the calculation.
         #
         # @return [Y2Storage::AgamaProposal]
-        def agama_proposal
+        def agama_proposal(devicegraph: nil)
           Y2Storage::AgamaProposal.new(config,
             product_config: product_config,
-            devicegraph:    probed_devicegraph,
-            disk_analyzer:  disk_analyzer,
+            devicegraph:    devicegraph&.dup,
             issues_list:    [])
         end
       end

--- a/web/src/api/storage.ts
+++ b/web/src/api/storage.ts
@@ -40,6 +40,8 @@ const fetchConfigModel = (): Promise<configModel.Config | undefined> =>
 
 const setConfig = (config: config.Config) => put("/api/storage/config", config);
 
+const setIncrementalConfig = (config) => put("/api/storage/incremental_config", config);
+
 /**
  * Returns the list of jobs
  */
@@ -69,6 +71,7 @@ export {
   fetchConfig,
   fetchConfigModel,
   setConfig,
+  setIncrementalConfig,
   fetchStorageJobs,
   findStorageJob,
   refresh,

--- a/web/src/components/storage/AddPartitionDialog.tsx
+++ b/web/src/components/storage/AddPartitionDialog.tsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) [2024] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React, { FormEvent, useState } from "react";
+import { Form, FormGroup, FormSelect, FormSelectOption, TextInput } from "@patternfly/react-core";
+import { Popup } from "~/components/core";
+import { _ } from "~/i18n";
+import { StorageDevice } from "~/types/storage";
+
+const MountPath = ({ value, onChange }) => {
+  const change = (_, v) => onChange(v);
+  return <TextInput value={value} onChange={change} aria-label={_("Mount path")} />;
+};
+
+const FsSelect = ({ value, onChange }) => {
+  const options = [
+    { value: "btrfs", label: "Btrfs" },
+    { value: "xfs", label: "XFS" },
+    { value: "ext4", label: "EXT4" },
+    { value: "swap", label: "Swap" },
+  ];
+
+  const change = (_, v) => onChange(v);
+
+  return (
+    <FormSelect value={value} onChange={change} aria-label={_("File system")}>
+      {options.map((option, index) => (
+        <FormSelectOption key={index} value={option.value} label={option.label} />
+      ))}
+    </FormSelect>
+  );
+};
+
+const Size = ({ value, onChange }) => {
+  const change = (_, v) => onChange(v);
+  return <TextInput value={value} onChange={change} aria-label={_("Size")} />;
+};
+
+export type AddPartitionDialogProps = {
+  device: StorageDevice;
+  isOpen?: boolean;
+  onCancel: () => void;
+  onAccept: (config) => void;
+};
+
+/**
+ * Renders a dialog that allows the user to add or edit a file system.
+ * @component
+ */
+export default function AddPartitionDialog({
+  device,
+  isOpen,
+  onCancel,
+  onAccept,
+}: AddPartitionDialogProps) {
+  const [path, setPath] = useState("");
+  const [fs, setFs] = useState("btrfs");
+  const [size, setSize] = useState("1 GiB");
+
+  const submitForm: (e: FormEvent) => void = (e) => {
+    e.preventDefault();
+
+    const config = {
+      storage: {
+        drives: [
+          {
+            search: device.name,
+            partitions: [{ filesystem: { path, type: fs }, size }],
+          },
+        ],
+      },
+    };
+
+    onAccept(config);
+  };
+
+  return (
+    /** @fixme blockSize medium is too big and small is too small. */
+    <Popup title={_("Add custom partition")} isOpen={isOpen} blockSize="medium" inlineSize="medium">
+      <Form id="add-partition-form" onSubmit={submitForm}>
+        <FormGroup label={_("Mount path")} fieldId="mountPath">
+          <MountPath value={path} onChange={setPath} />
+        </FormGroup>
+        <FormGroup label={_("File system")} fieldId="fsType">
+          <FsSelect value={fs} onChange={setFs} />
+        </FormGroup>
+        <FormGroup label={_("Size")} fieldId="size">
+          <Size value={size} onChange={setSize} />
+        </FormGroup>
+      </Form>
+      <Popup.Actions>
+        <Popup.Confirm form="add-partition-form" type="submit">
+          {_("Accept")}
+        </Popup.Confirm>
+        <Popup.Cancel onClick={onCancel} />
+      </Popup.Actions>
+    </Popup>
+  );
+}

--- a/web/src/components/storage/AdvancedDevicesSection.tsx
+++ b/web/src/components/storage/AdvancedDevicesSection.tsx
@@ -22,12 +22,13 @@
 
 import React from "react";
 import { Skeleton, Stack } from "@patternfly/react-core";
-import { EmptyState, Page } from "~/components/core";
+import { Page } from "~/components/core";
 import DevicesManager from "~/components/storage/DevicesManager";
 import AdvancedDevicesTable from "~/components/storage/AdvancedDevicesTable";
 import { _ } from "~/i18n";
 import { Action, StorageDevice } from "~/types/storage";
 import { ValidationError } from "~/types/issues";
+import { Alert } from "@patternfly/react-core";
 
 /**
  * @todo Create a component for rendering a customized skeleton
@@ -61,19 +62,15 @@ export default function ProposalResultSection({
   return (
     <Page.Section aria-label={_("The systems will be configured as displayed below.")}>
       {isLoading && <ResultSkeleton />}
-      {errors.length === 0 ? (
-        <AdvancedDevicesTable devicesManager={new DevicesManager(system, staging, actions)} />
-      ) : (
-        <EmptyState
-          icon="error"
-          title={_("Storage proposal not possible")}
-          color="danger-color-100"
-        >
-          {errors.map((e, i) => (
-            <div key={i}>{e.message}</div>
-          ))}
-        </EmptyState>
+      {errors.length > 0 && (
+        <Alert
+          variant="danger"
+          title={_("The requested action cannot be done")}
+          ouiaId="DangerAlert"
+          style={{ marginBlockEnd: "14px" }}
+        />
       )}
+      <AdvancedDevicesTable devicesManager={new DevicesManager(system, staging, actions)} />
     </Page.Section>
   );
 }

--- a/web/src/components/storage/AdvancedDevicesSection.tsx
+++ b/web/src/components/storage/AdvancedDevicesSection.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) [2024] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { Skeleton, Stack } from "@patternfly/react-core";
+import { EmptyState, Page } from "~/components/core";
+import DevicesManager from "~/components/storage/DevicesManager";
+import AdvancedDevicesTable from "~/components/storage/AdvancedDevicesTable";
+import { _ } from "~/i18n";
+import { Action, StorageDevice } from "~/types/storage";
+import { ValidationError } from "~/types/issues";
+
+/**
+ * @todo Create a component for rendering a customized skeleton
+ */
+const ResultSkeleton = () => (
+  <Stack hasGutter>
+    <Skeleton
+      screenreaderText={_("Waiting for information about storage configuration")}
+      width="80%"
+    />
+    <Skeleton width="65%" />
+    <Skeleton width="70%" />
+  </Stack>
+);
+
+export type ProposalResultSectionProps = {
+  system?: StorageDevice[];
+  staging?: StorageDevice[];
+  actions?: Action[];
+  errors?: ValidationError[];
+  isLoading?: boolean;
+};
+
+export default function ProposalResultSection({
+  system = [],
+  staging = [],
+  actions = [],
+  errors = [],
+  isLoading = false,
+}: ProposalResultSectionProps) {
+  return (
+    <Page.Section aria-label={_("The systems will be configured as displayed below.")}>
+      {isLoading && <ResultSkeleton />}
+      {errors.length === 0 ? (
+        <AdvancedDevicesTable devicesManager={new DevicesManager(system, staging, actions)} />
+      ) : (
+        <EmptyState
+          icon="error"
+          title={_("Storage proposal not possible")}
+          color="danger-color-100"
+        >
+          {errors.map((e, i) => (
+            <div key={i}>{e.message}</div>
+          ))}
+        </EmptyState>
+      )}
+    </Page.Section>
+  );
+}

--- a/web/src/components/storage/AdvancedDevicesTable.tsx
+++ b/web/src/components/storage/AdvancedDevicesTable.tsx
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) [2024] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { Label, Flex } from "@patternfly/react-core";
+import {
+  DeviceName,
+  DeviceDetails,
+  DeviceSize,
+  toStorageDevice,
+} from "~/components/storage/device-utils";
+import DevicesManager from "~/components/storage/DevicesManager";
+import { TreeTable } from "~/components/core";
+import { _ } from "~/i18n";
+import { sprintf } from "sprintf-js";
+import { deviceChildren, deviceSize } from "~/components/storage/utils";
+import { PartitionSlot, StorageDevice } from "~/types/storage";
+import { TreeTableColumn } from "~/components/core/TreeTable";
+
+type TableItem = StorageDevice | PartitionSlot;
+
+/**
+ * @component
+ */
+const MountPoint = ({ item }: { item: TableItem }) => {
+  const device = toStorageDevice(item);
+
+  if (!(device && device.filesystem?.mountPath)) return null;
+
+  return <em>{device.filesystem.mountPath}</em>;
+};
+
+/**
+ * @component
+ */
+const DeviceCustomDetails = ({
+  item,
+  devicesManager,
+}: {
+  item: TableItem;
+  devicesManager: DevicesManager;
+}) => {
+  const isNew = () => {
+    const device = toStorageDevice(item);
+    if (!device) return false;
+
+    // FIXME New PVs over a disk is not detected as new.
+    return !devicesManager.existInSystem(device) || devicesManager.hasNewFilesystem(device);
+  };
+
+  return (
+    <Flex direction={{ default: "row" }} gap={{ default: "gapXs" }}>
+      <DeviceDetails item={item} />
+      {isNew() && (
+        <Label color="green" isCompact>
+          {_("New")}
+        </Label>
+      )}
+    </Flex>
+  );
+};
+
+/**
+ * @component
+ */
+const DeviceCustomSize = ({
+  item,
+  devicesManager,
+}: {
+  item: TableItem;
+  devicesManager: DevicesManager;
+}) => {
+  const device = toStorageDevice(item);
+  const isResized = device && devicesManager.isShrunk(device);
+  const sizeBefore = isResized ? devicesManager.systemDevice(device.sid).size : item.size;
+
+  return (
+    <Flex direction={{ default: "row" }} gap={{ default: "gapXs" }}>
+      <DeviceSize item={item} />
+      {isResized && (
+        <Label color="orange" isCompact>
+          {
+            // TRANSLATORS: Label to indicate the device size before resizing, where %s is
+            // replaced by the original size (e.g., 3.00 GiB).
+            sprintf(_("Before %s"), deviceSize(sizeBefore))
+          }
+        </Label>
+      )}
+    </Flex>
+  );
+};
+
+const DeviceActions = ({ item }: { item: TableItem }) => {
+  const device = toStorageDevice(item);
+  if (!device) return;
+
+  return _("actions");
+};
+
+const columns: (devicesManager: DevicesManager) => TreeTableColumn[] = (devicesManager) => {
+  const renderDevice: (item: TableItem) => React.ReactNode = (item): React.ReactNode => (
+    <DeviceName item={item} />
+  );
+
+  const renderMountPoint: (item: TableItem) => React.ReactNode = (item) => (
+    <MountPoint item={item} />
+  );
+
+  const renderDetails: (item: TableItem) => React.ReactNode = (item) => (
+    <DeviceCustomDetails item={item} devicesManager={devicesManager} />
+  );
+
+  const renderSize: (item: TableItem) => React.ReactNode = (item) => (
+    <DeviceCustomSize item={item} devicesManager={devicesManager} />
+  );
+
+  const renderActions: (item: TableItem) => React.ReactNode = (item) => (
+    <DeviceActions item={item} />
+  );
+
+  return [
+    { name: _("Device"), value: renderDevice },
+    { name: _("Mount Point"), value: renderMountPoint },
+    { name: _("Details"), value: renderDetails },
+    { name: _("Size"), value: renderSize, classNames: "sizes-column" },
+    { name: undefined, value: renderActions },
+  ];
+};
+
+type ProposalResultTableProps = {
+  devicesManager: DevicesManager;
+};
+
+/**
+ * Renders the proposal result.
+ * @component
+ */
+export default function AdvancedDevicesTable({ devicesManager }: ProposalResultTableProps) {
+  // const devices = devicesManager.usedDevices();
+  const devices = devicesManager.stagingDevices();
+
+  return (
+    <TreeTable
+      columns={columns(devicesManager)}
+      items={devices}
+      expandedItems={devices}
+      itemChildren={deviceChildren}
+      rowClassNames={(item) => {
+        if (!item.sid) return "dimmed-row";
+      }}
+      className="proposal-result"
+    />
+  );
+}

--- a/web/src/components/storage/AdvancedPage.tsx
+++ b/web/src/components/storage/AdvancedPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2022-2024] SUSE LLC
+ * Copyright (c) [2024] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -23,8 +23,7 @@
 import React, { useRef } from "react";
 import { Grid, GridItem, Stack } from "@patternfly/react-core";
 import { Page, Drawer } from "~/components/core/";
-import ProposalResultSection from "./ProposalResultSection";
-import ProposalActionsSummary from "~/components/storage/ProposalActionsSummary";
+import AdvancedDevicesSection from "./AdvancedDevicesSection";
 import { ProposalActionsDialog } from "~/components/storage";
 import { _ } from "~/i18n";
 import { toValidationError } from "~/utils";
@@ -58,7 +57,7 @@ export const NOT_AFFECTED = {
   ProposalActionsSummary: [CHANGING.ENCRYPTION, CHANGING.TARGET],
 };
 
-export default function ProposalPage() {
+export default function AdvancedPage() {
   const drawerRef = useRef();
   const systemDevices = useDevices("system");
   const stagingDevices = useDevices("result");
@@ -84,7 +83,7 @@ export default function ProposalPage() {
   return (
     <Page>
       <Page.Header>
-        <h2>{_("Storage")}</h2>
+        <h2>{_("Advanced storage")}</h2>
       </Page.Header>
 
       <Page.Content>
@@ -96,17 +95,7 @@ export default function ProposalPage() {
               panelContent={<ProposalActionsDialog actions={actions} />}
             >
               <Stack hasGutter>
-                <ProposalActionsSummary
-                  system={systemDevices}
-                  staging={stagingDevices}
-                  errors={errors}
-                  actions={actions}
-                  // @ts-expect-error: we do not know how to specify the type of
-                  // drawerRef properly and TS does not find the "open" property
-                  onActionsClick={drawerRef.current?.open}
-                  isLoading={false}
-                />
-                <ProposalResultSection
+                <AdvancedDevicesSection
                   system={systemDevices}
                   staging={stagingDevices}
                   actions={actions}

--- a/web/src/components/storage/DevicesManager.js
+++ b/web/src/components/storage/DevicesManager.js
@@ -158,6 +158,19 @@ export default class DevicesManager {
   }
 
   /**
+   * @returns {StorageDevice[]}
+   */
+  stagingDevices() {
+    const sortFn = (a, b) => (a.name < b.name ? -1 : 1);
+
+    const drives = this.staging.filter((d) => d.isDrive).sort(sortFn);
+    const vgs = this.staging.filter((d) => d.type === "lvmVg").sort(sortFn);
+    const mds = this.staging.filter((d) => d.type === "md").sort(sortFn);
+
+    return [...drives, ...vgs, ...mds];
+  }
+
+  /**
    * Devices deleted.
    * @method
    *

--- a/web/src/components/storage/DevicesManager.js
+++ b/web/src/components/storage/DevicesManager.js
@@ -222,6 +222,18 @@ export default class DevicesManager {
     return compact(systems);
   }
 
+  parentInStaging(device) {
+    return this.#parent(device, this.staging);
+  }
+
+  #parent(device, source) {
+    if (device.type !== "partition") return;
+
+    return source
+      .filter((d) => d.isDrive)
+      .find((d) => (d.partitionTable?.partitions || []).find((p) => p.sid === device.sid));
+  }
+
   /**
    * @param {number} sid
    * @param {StorageDevice[]} source

--- a/web/src/components/storage/index.js
+++ b/web/src/components/storage/index.js
@@ -31,3 +31,4 @@ export { default as DeviceSelectorTable } from "./DeviceSelectorTable";
 export { default as DevicesFormSelect } from "./DevicesFormSelect";
 export { default as SpaceActionsTable } from "./SpaceActionsTable";
 export { default as DeviceSelection } from "./DeviceSelection";
+export { default as AdvancedPage } from "./AdvancedPage";

--- a/web/src/queries/storage.ts
+++ b/web/src/queries/storage.ts
@@ -28,7 +28,7 @@ import {
   useSuspenseQuery,
 } from "@tanstack/react-query";
 import React from "react";
-import { fetchConfig, fetchConfigModel, setConfig } from "~/api/storage";
+import { fetchConfig, fetchConfigModel, setConfig, setIncrementalConfig } from "~/api/storage";
 import { fetchDevices, fetchDevicesDirty } from "~/api/storage/devices";
 import {
   calculate,
@@ -144,6 +144,19 @@ const useConfigMutation = () => {
   const queryClient = useQueryClient();
   const query = {
     mutationFn: (config: config.Config) => setConfig(config),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["storage"] }),
+  };
+
+  return useMutation(query);
+};
+
+/**
+ * Hook for setting a new config.
+ */
+const useIncrementalConfigMutation = () => {
+  const queryClient = useQueryClient();
+  const query = {
+    mutationFn: (config) => setIncrementalConfig(config),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["storage"] }),
   };
 
@@ -334,6 +347,7 @@ const useDeprecatedChanges = () => {
 export {
   useConfig,
   useConfigMutation,
+  useIncrementalConfigMutation,
   useConfigModel,
   useDevices,
   useAvailableDevices,

--- a/web/src/routes/storage.tsx
+++ b/web/src/routes/storage.tsx
@@ -23,7 +23,7 @@
 import React from "react";
 import BootSelection from "~/components/storage/BootSelection";
 import SpacePolicySelection from "~/components/storage/SpacePolicySelection";
-import { DeviceSelection, ISCSIPage, ProposalPage } from "~/components/storage";
+import { DeviceSelection, ISCSIPage, ProposalPage, AdvancedPage } from "~/components/storage";
 
 import { Route } from "~/types/routes";
 import { N_ } from "~/i18n";
@@ -44,6 +44,7 @@ const PATHS = {
     root: "/storage/zfcp",
     activateDisk: "/storage/zfcp/active-disk",
   },
+  advanced: "/storage/advanced",
 };
 
 const routes = (): Route => ({
@@ -96,6 +97,10 @@ const routes = (): Route => ({
         if (!supportedZFCP()) return redirect(PATHS.targetDevice);
         return probeZFCP();
       },
+    },
+    {
+      path: PATHS.advanced,
+      element: <AdvancedPage />,
     },
   ],
 });


### PR DESCRIPTION
Draft code for the Hack Week project, see https://hackweek.opensuse.org/projects/agama-expert-partitioner.

The main goal of the project is to prove that the Agama infrastructure allows to implement something similar to the YaST Expert Partitioner with a reasonable effort.

This initial version supports the following use cases:

* List all devices.
* Delete all partitions from a disk.
* Automatically add the partitions for installation to a disk.
* Add partition for /home, swap or boot.
* Add a custom partition.
* Delete any individual partition.

[Demo](https://github.com/user-attachments/assets/61eb2443-70e2-4b80-90ff-f1f225de497f)

Notes:

* Requires changes in yast-storage-ng, see https://github.com/joseivanlopez/yast-storage-ng/pull/1