### PR TITLE
Displaying volume groups at the UI

### DIFF
--- a/web/src/api/storage/types/config-model.ts
+++ b/web/src/api/storage/types/config-model.ts
@@ -37,6 +37,7 @@ export interface Config {
   boot?: Boot;
   encryption?: Encryption;
   drives?: Drive[];
+  volumeGroups?: VolumeGroup[];
 }
 export interface Boot {
   configure: boolean;
@@ -82,4 +83,18 @@ export interface Size {
   default: boolean;
   min: number;
   max?: number;
+}
+export interface VolumeGroup {
+  name: string;
+  extentSize?: number;
+  targetDevices?: Alias[];
+  logicalVolumes?: LogicalVolume[];
+}
+export interface LogicalVolume {
+  name?: string;
+  mountPath?: string;
+  filesystem?: Filesystem;
+  size?: Size;
+  stripes?: number;
+  stripeSize?: number;
 }

--- a/web/src/components/storage/ConfigEditor.tsx
+++ b/web/src/components/storage/ConfigEditor.tsx
@@ -24,6 +24,7 @@ import React from "react";
 import { useDevices } from "~/queries/storage";
 import { useConfigModel } from "~/queries/storage/config-model";
 import DriveEditor from "~/components/storage/DriveEditor";
+import VolumeGroupEditor from "~/components/storage/VolumeGroupEditor";
 import { List, ListItem } from "@patternfly/react-core";
 
 export default function ConfigEditor() {
@@ -32,6 +33,13 @@ export default function ConfigEditor() {
 
   return (
     <List isPlain>
+      {model.volumeGroups.map((vg, i) => {
+        return (
+          <ListItem key={`vg-${i}`}>
+            <VolumeGroupEditor vg={vg} />
+          </ListItem>
+        );
+      })}
       {model.drives.map((drive, i) => {
         const device = devices.find((d) => d.name === drive.name);
 
@@ -42,7 +50,7 @@ export default function ConfigEditor() {
         if (device === undefined) return null;
 
         return (
-          <ListItem key={i}>
+          <ListItem key={`drive-${i}`}>
             <DriveEditor drive={drive} driveDevice={device} />
           </ListItem>
         );

--- a/web/src/components/storage/DriveEditor.test.tsx
+++ b/web/src/components/storage/DriveEditor.test.tsx
@@ -161,7 +161,6 @@ const drive2: ConfigModel.Drive = {
 };
 
 const mockDeleteDrive = jest.fn();
-const mockGetPartition = jest.fn();
 const mockDeletePartition = jest.fn();
 
 jest.mock("~/queries/storage", () => ({
@@ -176,7 +175,7 @@ jest.mock("~/queries/storage/config-model", () => ({
   useConfigModel: () => ({ drives: [drive1, drive2] }),
   useDrive: () => ({
     delete: mockDeleteDrive,
-    getPartition: mockGetPartition,
+    getPartition: (path) => drive1.partitions.find((p) => p.mountPath === path),
     deletePartition: mockDeletePartition,
   }),
 }));

--- a/web/src/components/storage/DriveEditor.tsx
+++ b/web/src/components/storage/DriveEditor.tsx
@@ -130,7 +130,7 @@ const SearchSelectorIntro = ({ drive }: { drive: configModel.Drive }) => {
   const driveModel = useDrive(drive.name);
   if (!driveModel) return;
 
-  const { isBoot, isExplicitBoot } = driveModel;
+  const { isBoot, isExplicitBoot, hasPv } = driveModel;
   // TODO: Get volume groups associated to the drive.
   const volumeGroups = [];
 
@@ -142,7 +142,7 @@ const SearchSelectorIntro = ({ drive }: { drive: configModel.Drive }) => {
 
     if (!driveUtils.hasFilesystem(drive)) {
       // The current device will be the only option to choose from
-      if (driveUtils.hasPv(drive)) {
+      if (hasPv) {
         if (volumeGroups.length > 1) {
           if (isExplicitBoot) {
             return _(
@@ -195,7 +195,7 @@ const SearchSelectorIntro = ({ drive }: { drive: configModel.Drive }) => {
 
     const name = baseName(drive.name);
 
-    if (driveUtils.hasPv(drive)) {
+    if (hasPv) {
       if (volumeGroups.length > 1) {
         if (isExplicitBoot) {
           return sprintf(
@@ -318,13 +318,13 @@ const SearchSelectorOptions = ({ drive, selected, onChange }) => {
   const driveModel = useDrive(drive.name);
   if (!driveModel) return;
 
-  const { isExplicitBoot } = driveModel;
+  const { isExplicitBoot, hasPv } = driveModel;
   // const boot = isExplicitBoot(drive.name);
 
   if (driveUtils.hasReuse(drive)) return <SearchSelectorSingleOption selected={selected} />;
 
   if (!driveUtils.hasFilesystem(drive)) {
-    if (driveUtils.hasPv(drive) || isExplicitBoot) {
+    if (hasPv || isExplicitBoot) {
       return <SearchSelectorSingleOption selected={selected} />;
     }
 
@@ -349,10 +349,10 @@ const RemoveDriveOption = ({ drive }) => {
 
   if (!driveModel) return;
 
-  const { isExplicitBoot, delete: deleteDrive } = driveModel;
+  const { isExplicitBoot, hasPv, delete: deleteDrive } = driveModel;
 
   if (isExplicitBoot) return;
-  if (driveUtils.hasPv(drive)) return;
+  if (hasPv) return;
   if (driveUtils.hasRoot(drive)) return;
 
   return (
@@ -390,11 +390,11 @@ const DriveSelector = ({ drive, selected, toggleAriaLabel }) => {
 };
 
 const DriveHeader = ({ drive, driveDevice }: DriveEditorProps) => {
-  const { isBoot } = useDrive(drive.name);
+  const { isBoot, hasPv } = useDrive(drive.name);
 
   const text = (drive: configModel.Drive): string => {
     if (driveUtils.hasRoot(drive)) {
-      if (driveUtils.hasPv(drive)) {
+      if (hasPv) {
         if (isBoot) {
           // TRANSLATORS: %s will be replaced by the device name and its size - "/dev/sda, 20 GiB"
           return _("Use %s to install, host LVM and boot");
@@ -412,7 +412,7 @@ const DriveHeader = ({ drive, driveDevice }: DriveEditorProps) => {
     }
 
     if (driveUtils.hasFilesystem(drive)) {
-      if (driveUtils.hasPv(drive)) {
+      if (hasPv) {
         if (isBoot) {
           // TRANSLATORS: %s will be replaced by the device name and its size - "/dev/sda, 20 GiB"
           return _("Use %s for LVM, additional partitions and booting");
@@ -429,7 +429,7 @@ const DriveHeader = ({ drive, driveDevice }: DriveEditorProps) => {
       return _("Use %s for additional partitions");
     }
 
-    if (driveUtils.hasPv(drive)) {
+    if (hasPv) {
       if (isBoot) {
         // TRANSLATORS: %s will be replaced by the device name and its size - "/dev/sda, 20 GiB"
         return _("Use %s to host LVM and boot");

--- a/web/src/components/storage/DriveEditor.tsx
+++ b/web/src/components/storage/DriveEditor.tsx
@@ -33,7 +33,7 @@ import { useDrive } from "~/queries/storage/config-model";
 import * as driveUtils from "~/components/storage/utils/drive";
 import * as partitionUtils from "~/components/storage/utils/partition";
 import { contentDescription } from "~/components/storage/utils/device";
-import { DeviceMenu } from "~/components/storage/utils/configEditor";
+import { DeviceHeader, DeviceMenu } from "~/components/storage/utils/configEditor";
 import { Icon } from "../layout";
 import { MenuHeader } from "~/components/core";
 import MenuDeviceDescription from "./MenuDeviceDescription";
@@ -445,17 +445,13 @@ const DriveHeader = ({ drive, driveDevice }: DriveEditorProps) => {
     // TRANSLATORS: %s will be replaced by the device name and its size - "/dev/sda, 20 GiB"
     return _("Use %s");
   };
-
-  const [txt1, txt2] = text(drive).split("%s");
   // TRANSLATORS: a disk drive
   const toggleAriaLabel = _("Drive");
 
   return (
-    <h4>
-      <span>{txt1}</span>
+    <DeviceHeader title={text(drive)}>
       <DriveSelector drive={drive} selected={driveDevice} toggleAriaLabel={toggleAriaLabel} />
-      <span>{txt2}</span>
-    </h4>
+    </DeviceHeader>
   );
 };
 

--- a/web/src/components/storage/DriveEditor.tsx
+++ b/web/src/components/storage/DriveEditor.tsx
@@ -25,16 +25,18 @@ import { useNavigate, generatePath } from "react-router-dom";
 import { _, formatList } from "~/i18n";
 import { sprintf } from "sprintf-js";
 import { baseName, deviceLabel, formattedPath, SPACE_POLICIES } from "~/components/storage/utils";
-import { useAvailableDevices, useVolume } from "~/queries/storage";
+import { useAvailableDevices } from "~/queries/storage";
 import { configModel } from "~/api/storage/types";
 import { StorageDevice } from "~/types/storage";
 import { STORAGE as PATHS } from "~/routes/paths";
 import { useDrive } from "~/queries/storage/config-model";
 import * as driveUtils from "~/components/storage/utils/drive";
-import * as partitionUtils from "~/components/storage/utils/partition";
 import { contentDescription } from "~/components/storage/utils/device";
-import { DeviceHeader, DeviceMenu } from "~/components/storage/utils/configEditor";
-import { Icon } from "../layout";
+import {
+  DeviceHeader,
+  DeviceMenu,
+  MountPathMenuItem,
+} from "~/components/storage/utils/configEditor";
 import { MenuHeader } from "~/components/core";
 import MenuDeviceDescription from "./MenuDeviceDescription";
 import {
@@ -47,7 +49,6 @@ import {
   Label,
   Split,
   MenuItem,
-  MenuItemAction,
   MenuList,
   MenuGroup,
 } from "@patternfly/react-core";
@@ -481,48 +482,15 @@ const PartitionsNoContentSelector = ({ drive, toggleAriaLabel }) => {
 };
 
 const PartitionMenuItem = ({ driveName, mountPath }) => {
-  const navigate = useNavigate();
   const drive = useDrive(driveName);
   const partition = drive.getPartition(mountPath);
-  const volume = useVolume(mountPath);
-  const isRequired = volume.outline?.required || false;
-  const description = partition ? partitionUtils.typeWithSize(partition) : null;
+  const editPath = generatePath(PATHS.editPartition, {
+    id: baseName(driveName),
+    partitionId: encodeURIComponent(mountPath),
+  });
 
   return (
-    <MenuItem
-      itemId={mountPath}
-      description={description}
-      role="menuitem"
-      actions={
-        <>
-          <MenuItemAction
-            style={{ alignSelf: "center" }}
-            icon={<Icon name="edit_square" aria-label={"Edit"} />}
-            actionId={`edit-${mountPath}`}
-            aria-label={`Edit ${mountPath}`}
-            onClick={() =>
-              navigate(
-                generatePath(PATHS.editPartition, {
-                  id: baseName(driveName),
-                  partitionId: encodeURIComponent(mountPath),
-                }),
-              )
-            }
-          />
-          {!isRequired && (
-            <MenuItemAction
-              style={{ alignSelf: "center" }}
-              icon={<Icon name="delete" aria-label={"Delete"} />}
-              actionId={`delete-${mountPath}`}
-              aria-label={`Delete ${mountPath}`}
-              onClick={() => drive.deletePartition(mountPath)}
-            />
-          )}
-        </>
-      }
-    >
-      {mountPath}
-    </MenuItem>
+    <MountPathMenuItem device={partition} editPath={editPath} deleteFn={drive.deletePartition} />
   );
 };
 

--- a/web/src/components/storage/VolumeGroupEditor.tsx
+++ b/web/src/components/storage/VolumeGroupEditor.tsx
@@ -24,8 +24,13 @@ import React from "react";
 import { _ } from "~/i18n";
 import { sprintf } from "sprintf-js";
 import { configModel } from "~/api/storage/types";
+import { contentDescription } from "~/components/storage/utils/volumeGroup";
 import { useVolumeGroup } from "~/queries/storage/config-model";
-import { DeviceHeader, DeviceMenu } from "~/components/storage/utils/configEditor";
+import {
+  DeviceHeader,
+  DeviceMenu,
+  MountPathMenuItem,
+} from "~/components/storage/utils/configEditor";
 import {
   Card,
   CardBody,
@@ -72,10 +77,29 @@ const VgMenu = ({ vg }) => {
 };
 
 const VgHeader = ({ vg }: VolumeGroupEditorProps) => {
+  const title = vg.logicalVolumes.length
+    ? _("Create LVM volume group %s")
+    : _("Empty LVM volume group %s");
+
   return (
-    <DeviceHeader title={_("Create LVM volume group %s")}>
+    <DeviceHeader title={title}>
       <VgMenu vg={vg} />
     </DeviceHeader>
+  );
+};
+
+const LogicalVolumes = ({ vg }) => {
+  return (
+    <DeviceMenu
+      title={<span aria-hidden>{contentDescription(vg)}</span>}
+      ariaLabel={_("Logical volumes")}
+    >
+      <MenuList>
+        {vg.logicalVolumes.map((lv) => {
+          return <MountPathMenuItem key={lv.mountPath} device={lv} />;
+        })}
+      </MenuList>
+    </DeviceMenu>
   );
 };
 
@@ -88,7 +112,9 @@ export default function VolumeGroupEditor({ vg }: VolumeGroupEditorProps) {
         </CardTitle>
       </CardHeader>
       <CardBody className={spacingStyles.plLg}>
-        <Flex direction={{ default: "column" }} />
+        <Flex direction={{ default: "column" }}>
+          <LogicalVolumes vg={vg} />
+        </Flex>
       </CardBody>
     </Card>
   );

--- a/web/src/components/storage/VolumeGroupEditor.tsx
+++ b/web/src/components/storage/VolumeGroupEditor.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) [2025] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { _ } from "~/i18n";
+import { sprintf } from "sprintf-js";
+import { configModel } from "~/api/storage/types";
+import { useVolumeGroup } from "~/queries/storage/config-model";
+import { DeviceHeader, DeviceMenu } from "~/components/storage/utils/configEditor";
+import {
+  Card,
+  CardBody,
+  CardHeader,
+  CardTitle,
+  Flex,
+  MenuItem,
+  MenuList,
+} from "@patternfly/react-core";
+
+import spacingStyles from "@patternfly/react-styles/css/utilities/Spacing/spacing";
+
+export type VolumeGroupEditorProps = { vg: configModel.VolumeGroup };
+
+const RemoveVgOption = ({ vg }) => {
+  const volumeGroup = useVolumeGroup(vg.name);
+  const drive = volumeGroup.targetDrives[0];
+  const desc = sprintf(_("The logical volumes will become partitions at %s"), drive.name);
+
+  return (
+    <MenuItem isDanger description={desc}>
+      {_("Do not create")}
+    </MenuItem>
+  );
+};
+
+const EditVgOption = () => {
+  return (
+    <MenuItem description={_("Modify settings and physical volumes")}>
+      {_("Edit volume group")}
+    </MenuItem>
+  );
+};
+
+const VgMenu = ({ vg }) => {
+  return (
+    <DeviceMenu title={<b aria-hidden>{vg.name}</b>}>
+      <MenuList>
+        <EditVgOption />
+        <RemoveVgOption vg={vg} />
+      </MenuList>
+    </DeviceMenu>
+  );
+};
+
+const VgHeader = ({ vg }: VolumeGroupEditorProps) => {
+  return (
+    <DeviceHeader title={_("Create LVM volume group %s")}>
+      <VgMenu vg={vg} />
+    </DeviceHeader>
+  );
+};
+
+export default function VolumeGroupEditor({ vg }: VolumeGroupEditorProps) {
+  return (
+    <Card isCompact>
+      <CardHeader>
+        <CardTitle>
+          <VgHeader vg={vg} />
+        </CardTitle>
+      </CardHeader>
+      <CardBody className={spacingStyles.plLg}>
+        <Flex direction={{ default: "column" }} />
+      </CardBody>
+    </Card>
+  );
+}

--- a/web/src/components/storage/utils/configEditor.tsx
+++ b/web/src/components/storage/utils/configEditor.tsx
@@ -23,11 +23,16 @@
 // @ts-check
 
 import React, { useId, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useVolume } from "~/queries/storage";
+import * as partitionUtils from "~/components/storage/utils/partition";
 import { Icon } from "../../layout";
 import {
   Menu,
   MenuContainer,
   MenuContent,
+  MenuItem,
+  MenuItemAction,
   MenuToggle,
   MenuToggleProps,
   MenuToggleElement,
@@ -98,4 +103,42 @@ const DeviceHeader = ({ title, children }) => {
   );
 };
 
-export { DeviceHeader, DeviceMenu };
+const MountPathMenuItem = ({ device, editPath = undefined, deleteFn = undefined }) => {
+  const navigate = useNavigate();
+  const mountPath = device.mountPath;
+  const volume = useVolume(mountPath);
+  const isRequired = volume.outline?.required || false;
+  const description = device ? partitionUtils.typeWithSize(device) : null;
+
+  return (
+    <MenuItem
+      itemId={mountPath}
+      description={description}
+      role="menuitem"
+      actions={
+        <>
+          <MenuItemAction
+            style={{ alignSelf: "center" }}
+            icon={<Icon name="edit_square" aria-label={"Edit"} />}
+            actionId={`edit-${mountPath}`}
+            aria-label={`Edit ${mountPath}`}
+            onClick={() => editPath && navigate(editPath)}
+          />
+          {!isRequired && (
+            <MenuItemAction
+              style={{ alignSelf: "center" }}
+              icon={<Icon name="delete" aria-label={"Delete"} />}
+              actionId={`delete-${mountPath}`}
+              aria-label={`Delete ${mountPath}`}
+              onClick={() => deleteFn && deleteFn(mountPath)}
+            />
+          )}
+        </>
+      }
+    >
+      {mountPath}
+    </MenuItem>
+  );
+};
+
+export { DeviceHeader, DeviceMenu, MountPathMenuItem };

--- a/web/src/components/storage/utils/configEditor.tsx
+++ b/web/src/components/storage/utils/configEditor.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) [2025] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+// @ts-check
+
+import React, { useId, useRef, useState } from "react";
+import { Icon } from "../../layout";
+import {
+  Menu,
+  MenuContainer,
+  MenuContent,
+  MenuToggle,
+  MenuToggleProps,
+  MenuToggleElement,
+} from "@patternfly/react-core";
+
+export const InlineMenuToggle = React.forwardRef(
+  (props: MenuToggleProps, ref: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      icon={<Icon name="keyboard_arrow_down" />}
+      innerRef={ref}
+      variant="plain"
+      className="agm-inline-menu-toggle"
+      {...props}
+    />
+  ),
+);
+
+const DeviceMenu = ({ title, ariaLabel = undefined, activeItemId = undefined, children }) => {
+  const menuId = useId();
+  const menuRef = useRef();
+  const toggleMenuRef = useRef();
+  const [isOpen, setIsOpen] = useState(false);
+  const onToggle = () => setIsOpen(!isOpen);
+
+  return (
+    <MenuContainer
+      isOpen={isOpen}
+      onOpenChange={setIsOpen}
+      toggleRef={toggleMenuRef}
+      toggle={
+        <InlineMenuToggle
+          ref={toggleMenuRef}
+          onClick={onToggle}
+          isExpanded={isOpen}
+          aria-label={ariaLabel}
+          aria-controls={menuId}
+        >
+          {title}
+        </InlineMenuToggle>
+      }
+      menuRef={menuRef}
+      menu={
+        <Menu
+          ref={menuRef}
+          activeItemId={activeItemId}
+          role="menu"
+          id={menuId}
+          onSelect={() => setIsOpen(false)}
+        >
+          <MenuContent>{children}</MenuContent>
+        </Menu>
+      }
+      // @ts-expect-error
+      popperProps={{ appendTo: document.body }}
+    />
+  );
+};
+
+export { DeviceMenu };

--- a/web/src/components/storage/utils/configEditor.tsx
+++ b/web/src/components/storage/utils/configEditor.tsx
@@ -86,4 +86,16 @@ const DeviceMenu = ({ title, ariaLabel = undefined, activeItemId = undefined, ch
   );
 };
 
-export { DeviceMenu };
+const DeviceHeader = ({ title, children }) => {
+  const [txt1, txt2] = title.split("%s");
+
+  return (
+    <h4>
+      <span>{txt1}</span>
+      {children}
+      <span>{txt2}</span>
+    </h4>
+  );
+};
+
+export { DeviceHeader, DeviceMenu };

--- a/web/src/components/storage/utils/drive.tsx
+++ b/web/src/components/storage/utils/drive.tsx
@@ -157,14 +157,7 @@ const hasReuse = (drive: configModel.Drive): boolean => {
   return drive.partitions && drive.partitions.some((p) => p.mountPath && p.name);
 };
 
-// TODO: maybe it should be moved to Drive hook from config-model.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const hasPv = (drive: configModel.Drive): boolean => {
-  return false;
-};
-
 export {
-  hasPv,
   hasReuse,
   hasFilesystem,
   hasRoot,

--- a/web/src/components/storage/utils/partition.tsx
+++ b/web/src/components/storage/utils/partition.tsx
@@ -30,7 +30,7 @@ import { configModel } from "~/api/storage/types";
 /**
  * String to identify the drive.
  */
-const pathWithSize = (partition: configModel.Partition): string => {
+const pathWithSize = (partition: configModel.Partition | configModel.LogicalVolume): string => {
   return sprintf(
     // TRANSLATORS: %1$s is an already formatted mount path (eg. "/"),
     // %2$s is a size description (eg. at least 10 GiB)
@@ -43,7 +43,7 @@ const pathWithSize = (partition: configModel.Partition): string => {
 /**
  * String to identify the type of partition to be created (or used).
  */
-const typeDescription = (partition: configModel.Partition): string => {
+const typeDescription = (partition: configModel.Partition | configModel.LogicalVolume): string => {
   const fs = filesystemType(partition.filesystem);
 
   if (partition.name) {
@@ -64,7 +64,7 @@ const typeDescription = (partition: configModel.Partition): string => {
 /**
  * Combination of {@link typeDescription} and the size of the target partition.
  */
-const typeWithSize = (partition: configModel.Partition): string => {
+const typeWithSize = (partition: configModel.Partition | configModel.LogicalVolume): string => {
   return sprintf(
     // TRANSLATORS: %1$s is a filesystem type description (eg. "Btrfs with snapshots"),
     // %2$s is a description of the size or the size limits (eg. "at least 10 GiB")

--- a/web/src/components/storage/utils/volumeGroup.tsx
+++ b/web/src/components/storage/utils/volumeGroup.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) [2025] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+// @ts-check
+
+import { _, n_, formatList } from "~/i18n";
+import { configModel } from "~/api/storage/types";
+import { formattedPath } from "~/components/storage/utils";
+import { sprintf } from "sprintf-js";
+
+const contentDescription = (vg: configModel.VolumeGroup): string => {
+  if (vg.logicalVolumes.length === 0) return _("No logical volumes are defined yet");
+
+  const mountPaths = vg.logicalVolumes.map((v) => formattedPath(v.mountPath));
+  return sprintf(
+    // TRANSLATORS: %s is a list of formatted mount points like '"/", "/var" and "swap"' (or a
+    // single mount point in the singular case).
+    n_(
+      "A new logical volume will be created for %s",
+      "New logical volumes will be created for %s",
+      mountPaths.length,
+    ),
+    formatList(mountPaths),
+  );
+};
+
+export { contentDescription };

--- a/web/src/queries/storage/config-model.ts
+++ b/web/src/queries/storage/config-model.ts
@@ -85,6 +85,12 @@ function isExplicitBoot(model: configModel.Config, driveName: string): boolean {
   return !model.boot?.device?.default && driveName === model.boot?.device?.name;
 }
 
+function driveHasPv(model: configModel.Config, driveAlias: string): boolean {
+  if (!driveAlias) return false;
+
+  return model.volumeGroups.flatMap((g) => g.targetDevices).includes(driveAlias);
+}
+
 function allMountPaths(drive: configModel.Drive): string[] {
   if (drive.mountPath) return [drive.mountPath];
 
@@ -411,6 +417,7 @@ export function useEncryption(): EncryptionHook {
 export type DriveHook = {
   isBoot: boolean;
   isExplicitBoot: boolean;
+  hasPv: boolean;
   allMountPaths: string[];
   configuredExistingPartitions: configModel.Partition[];
   switch: (newName: string) => void;
@@ -432,6 +439,7 @@ export function useDrive(name: string): DriveHook | null {
   return {
     isBoot: isBoot(model, name),
     isExplicitBoot: isExplicitBoot(model, name),
+    hasPv: driveHasPv(model, drive.alias),
     allMountPaths: allMountPaths(drive),
     configuredExistingPartitions: configuredExistingPartitions(drive),
     switch: (newName) => mutate(switchDrive(model, name, newName)),


### PR DESCRIPTION
First implementation of a VolumeGroupEditor component.

Some of the actions are just placeholder for future operations, but I thing that's correct at this point in time.

## Bonus

Common functionality (eg. components for our dropdown menus or to represent mount points) extracted to `utils/configEditor`

## Screenshots

![vgs](https://github.com/user-attachments/assets/6a5236ac-30c2-4902-8b2c-71dba7fb52fb)

<details>
<summary>More screenshots</summary>

![vgs-menu1](https://github.com/user-attachments/assets/e8c58872-b634-456b-a09e-6950a595754f)

![vgs-menu2](https://github.com/user-attachments/assets/25e290a9-c80d-496b-9ae6-96ba51a360fe)

</details>