### PR TITLE
Separate storage configure issues and storage probing issues

### DIFF
--- a/service/lib/agama/dbus/manager.rb
+++ b/service/lib/agama/dbus/manager.rb
@@ -78,7 +78,6 @@ module Agama
       # Runs the config phase
       #
       # @param reprobe [Boolean] Whether a reprobe should be done instead of a probe.
-      # @param data [Hash] Extra data provided to the D-Bus calls.
       def config_phase(reprobe: false)
         safe_run do
           busy_while { backend.config_phase(reprobe: reprobe) }

--- a/service/lib/agama/dbus/storage.rb
+++ b/service/lib/agama/dbus/storage.rb
@@ -29,4 +29,3 @@ end
 
 require "agama/dbus/storage/iscsi"
 require "agama/dbus/storage/manager"
-require "agama/dbus/storage/proposal"

--- a/service/lib/agama/dbus/storage/manager.rb
+++ b/service/lib/agama/dbus/storage/manager.rb
@@ -76,7 +76,7 @@ module Agama
           dbus_method(:GetConfig, "out config:s") { recover_config }
           dbus_method(:SetConfig, "in config:s") { |c| configure(c) }
           dbus_method(:GetConfigModel, "out model:s") { recover_config_model }
-          dbus_method(:SetConfigModel, "in model:s") { |m| configure_with_model(m)}
+          dbus_method(:SetConfigModel, "in model:s") { |m| configure_with_model(m) }
           dbus_method(:SolveConfigModel, "in model:s, out result:s") { |m| solve_config_model(m) }
           dbus_method(:GetProposal, "out proposal:s") { recover_proposal }
           dbus_method(:GetIssues, "out issues:s") { recover_issues }

--- a/service/lib/agama/dbus/storage/manager.rb
+++ b/service/lib/agama/dbus/storage/manager.rb
@@ -166,6 +166,8 @@ module Agama
         # NOTE: memoization of the values?
         # @return [String]
         def recover_system
+          return nil.to_json unless backend.probed?
+
           json = {
             devices:            json_devices(:probed),
             availableDrives:    available_drives,
@@ -246,6 +248,8 @@ module Agama
         # NOTE: memoization of the values?
         # @return [String]
         def recover_proposal
+          return nil.to_json unless backend.proposal.calculated?
+
           json = {
             devices: json_devices(:staging),
             actions: actions

--- a/service/lib/agama/dbus/storage/manager.rb
+++ b/service/lib/agama/dbus/storage/manager.rb
@@ -44,7 +44,6 @@ module Agama
         include Yast::I18n
         include Agama::WithProgress
         include ::DBus::ObjectManager
-        include DBus::Interfaces::Issues
 
         PATH = "/org/opensuse/Agama/Storage1"
         private_constant :PATH
@@ -248,7 +247,7 @@ module Agama
         # NOTE: memoization of the values?
         # @return [String]
         def recover_proposal
-          return nil.to_json unless backend.proposal.calculated?
+          return nil.to_json unless backend.proposal.success?
 
           json = {
             devices: json_devices(:staging),

--- a/service/lib/agama/dbus/storage/manager.rb
+++ b/service/lib/agama/dbus/storage/manager.rb
@@ -42,7 +42,7 @@ module Agama
       class Manager < BaseObject # rubocop:disable Metrics/ClassLength
         extend Yast::I18n
         include Yast::I18n
-        include WithProgress
+        include Agama::WithProgress
         include ::DBus::ObjectManager
         include DBus::Interfaces::Issues
 

--- a/service/lib/agama/progress.rb
+++ b/service/lib/agama/progress.rb
@@ -22,6 +22,7 @@
 require "json"
 
 module Agama
+  # Class to keep track of a process divided in a set of steps.
   class Progress
     class MissingStep < StandardError; end
 

--- a/service/lib/agama/progress.rb
+++ b/service/lib/agama/progress.rb
@@ -53,7 +53,7 @@ module Agama
     def initialize(size, step)
       @size = size
       @steps = []
-      @step= step
+      @step = step
       @index = 1
     end
 

--- a/service/lib/agama/storage/manager.rb
+++ b/service/lib/agama/storage/manager.rb
@@ -66,9 +66,11 @@ module Agama
         !!@activated
       end
 
+      # Resets any information regarding activation of devices that may be cached by Y2Storage.
+      #
+      # Note this does NOT deactivate any device. There is not way to revert a previous activation.
       def reset_activation
         Y2Storage::Luks.reset_activation_infos
-        @activated = false
       end
 
       # Activates the devices.

--- a/service/lib/agama/storage/manager.rb
+++ b/service/lib/agama/storage/manager.rb
@@ -169,6 +169,13 @@ module Agama
         @security ||= Security.new(logger, product_config)
       end
 
+      # Issues from the system
+      #
+      # @return [Array<Issue>]
+      def system_issues
+        probing_issues + [candidate_devices_issue].compact
+      end
+
     private
 
       PROPOSAL_ID = "storage_proposal"
@@ -193,18 +200,7 @@ module Agama
 
       # Recalculates the list of issues
       def update_issues
-        self.issues = system_issues + proposal.issues
-      end
-
-      # Issues from the system
-      #
-      # @return [Array<Issue>]
-      def system_issues
-        issues = probing_issues + [
-          candidate_devices_issue
-        ]
-
-        issues.compact
+        self.issues = proposal.issues
       end
 
       # Issues from the probing phase

--- a/service/lib/agama/with_progress.rb
+++ b/service/lib/agama/with_progress.rb
@@ -22,6 +22,7 @@
 require "agama/progress"
 
 module Agama
+  # Mixin to use Agama::Progress to track the status of an object.
   module WithProgress
     attr_reader :progress
 

--- a/service/test/agama/dbus/clients/storage_test.rb
+++ b/service/test/agama/dbus/clients/storage_test.rb
@@ -31,22 +31,19 @@ describe Agama::DBus::Clients::Storage do
     allow(bus).to receive(:service).with("org.opensuse.Agama.Storage1").and_return(service)
     allow(service).to receive(:[]).with("/org/opensuse/Agama/Storage1").and_return(dbus_object)
     allow(dbus_object).to receive(:introspect)
-    allow(dbus_object).to receive(:[]).with("org.opensuse.Agama.Storage1").and_return(storage_iface)
   end
 
   let(:bus) { instance_double(Agama::DBus::Bus) }
   let(:service) { instance_double(::DBus::ProxyService) }
-
   let(:dbus_object) { instance_double(::DBus::ProxyObject) }
-  let(:storage_iface) { instance_double(::DBus::ProxyObjectInterface) }
 
   subject { described_class.new }
 
   describe "#probe" do
-    let(:storage_iface) { double(::DBus::ProxyObjectInterface, Probe: nil) }
+    let(:dbus_object) { double(::DBus::ProxyObject, Probe: nil) }
 
     it "calls the D-Bus Probe method" do
-      expect(storage_iface).to receive(:Probe)
+      expect(dbus_object).to receive(:Probe)
 
       subject.probe
     end
@@ -54,7 +51,7 @@ describe Agama::DBus::Clients::Storage do
     context "when a block is given" do
       it "passes the block to the Probe method (async)" do
         callback = proc {}
-        expect(storage_iface).to receive(:Probe) do |&block|
+        expect(dbus_object).to receive(:Probe) do |&block|
           expect(block).to be(callback)
         end
 

--- a/service/test/agama/dbus/storage/manager_test.rb
+++ b/service/test/agama/dbus/storage/manager_test.rb
@@ -82,28 +82,6 @@ describe Agama::DBus::Storage::Manager do
     mock_storage(devicegraph: "empty-hd-50GiB.yaml")
   end
 
-  describe "#deprecated_system" do
-    before do
-      allow(backend).to receive(:deprecated_system?).and_return(deprecated)
-    end
-
-    context "if the system is set as deprecated" do
-      let(:deprecated) { true }
-
-      it "returns true" do
-        expect(subject.deprecated_system).to eq(true)
-      end
-    end
-
-    context "if the system is not set as deprecated" do
-      let(:deprecated) { false }
-
-      it "returns false" do
-        expect(subject.deprecated_system).to eq(false)
-      end
-    end
-  end
-
   describe "#recover_proposal" do
     describe "recover_proposal[:actions]" do
       before do

--- a/service/test/agama/dbus/storage/manager_test.rb
+++ b/service/test/agama/dbus/storage/manager_test.rb
@@ -83,9 +83,9 @@ describe Agama::DBus::Storage::Manager do
   end
 
   describe "#recover_proposal" do
-    context "if no proposal has been calculated" do
+    context "if no proposal has been successfully calculated" do
       before do
-        allow(proposal).to receive(:calculated?).and_return false
+        allow(proposal).to receive(:success?).and_return false
       end
 
       it "returns 'null'" do
@@ -93,9 +93,9 @@ describe Agama::DBus::Storage::Manager do
       end
     end
 
-    context "if a proposal was already calculated" do
+    context "if a proposal was successfully calculated" do
       before do
-        allow(proposal).to receive(:calculated?).and_return true
+        allow(proposal).to receive(:success?).and_return true
       end
 
       describe "recover_proposal[:actions]" do
@@ -836,7 +836,7 @@ describe Agama::DBus::Storage::Manager do
         }
       end
 
-      it "returns an empty array" do
+      it "returns the list of proposal issues" do
         result = parse(subject.recover_issues)
         expect(result).to include(
           a_hash_including(

--- a/service/test/agama/dbus/storage_service_test.rb
+++ b/service/test/agama/dbus/storage_service_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2025] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "agama/dbus/storage_service"
+
+describe Agama::DBus::StorageService do
+  subject(:service) { described_class.new(config, logger) }
+
+  let(:config) { Agama::Config.new }
+  let(:logger) { Logger.new($stdout, level: :warn) }
+  let(:manager) { Agama::Storage::Manager.new(config, logger: logger) }
+  let(:inhibitors) { instance_double(Y2Storage::Inhibitors, inhibit: nil, uninhibit: nil) }
+
+  let(:object_server) { instance_double(DBus::ObjectServer, export: nil) }
+  let(:bus) { instance_double(Agama::DBus::Bus, request_name: nil) }
+
+  let(:manager_obj) do
+    instance_double(Agama::DBus::Storage::Manager, path: "/org/opensuse/Agama/Storage1")
+  end
+
+  before do
+    allow(Agama::DBus::Bus).to receive(:current).and_return(bus)
+    allow(bus).to receive(:request_service).with("org.opensuse.Agama.Storage1")
+      .and_return(object_server)
+    allow(Y2Storage::Inhibitors).to receive(:new).and_return inhibitors
+    allow(Agama::Storage::Manager).to receive(:new).with(config, logger: logger)
+      .and_return(manager)
+    allow(Agama::DBus::Storage::Manager).to receive(:new).with(manager, logger: logger)
+      .and_return(manager_obj)
+  end
+
+  describe "#start" do
+    before { allow(ENV).to receive(:[]=) }
+
+    it "sets env YAST_NO_BLS_BOOT to yes if product doesn't requires bls boot explicitly" do
+      expect(config).to receive(:boot_strategy).and_return(nil)
+      expect(ENV).to receive(:[]=).with("YAST_NO_BLS_BOOT", "1")
+
+      service.start
+    end
+
+    it "activates the Y2Storage inhibitors" do
+      expect(inhibitors).to receive(:inhibit)
+
+      service.start
+    end
+  end
+
+  describe "#export" do
+    it "exports the storage manager" do
+      expect(object_server).to receive(:export).with(manager_obj)
+      service.export
+    end
+  end
+
+  describe "#dispatch" do
+    it "dispatches the messages from the bus" do
+      expect(bus).to receive(:dispatch_message_queue)
+      service.dispatch
+    end
+  end
+end

--- a/service/test/agama/manager_test.rb
+++ b/service/test/agama/manager_test.rb
@@ -57,8 +57,8 @@ describe Agama::Manager do
   let(:network) { instance_double(Agama::Network, install: nil, startup: nil) }
   let(:storage) do
     instance_double(
-      Agama::DBus::Clients::Storage, probe: nil, reprobe: nil, install: nil, finish: nil,
-      on_service_status_change: nil, errors?: false
+      Agama::DBus::Clients::Storage, probe: nil, install: nil, finish: nil,
+      :product= => nil, errors?: false
     )
   end
   let(:scripts) do
@@ -115,27 +115,28 @@ describe Agama::Manager do
   end
 
   describe "#config_phase" do
+    let(:product) { "Geecko" }
+
     it "sets the installation phase to config" do
       subject.config_phase
       expect(subject.installation_phase.config?).to eq(true)
     end
 
-    it "calls #probe method of each module" do
-      expect(storage).to receive(:probe)
-      expect(software).to receive(:probe)
+    it "sets the product for the storage module" do
+      expect(storage).to receive(:product=).with product
       subject.config_phase
     end
 
-    context "if reprobe is requested" do
-      it "calls #reprobe method of the storage module" do
-        expect(storage).to receive(:reprobe)
-        subject.config_phase(reprobe: true)
-      end
+    it "calls #probe method for both software and storage modules if reprobe is requested" do
+      expect(storage).to receive(:probe)
+      expect(software).to receive(:probe)
+      subject.config_phase(reprobe: true)
+    end
 
-      it "calls #probe method of the software module" do
-        expect(software).to receive(:probe)
-        subject.config_phase(reprobe: true)
-      end
+    it "calls #probe method only for the software module if reprobe is not requested" do
+      expect(software).to receive(:probe)
+      expect(storage).to_not receive(:probe)
+      subject.config_phase(reprobe: false)
     end
   end
 

--- a/service/test/agama/storage/manager_test.rb
+++ b/service/test/agama/storage/manager_test.rb
@@ -157,7 +157,7 @@ describe Agama::Storage::Manager do
     context "if there are available devices" do
       let(:devices) { [disk1] }
 
-      it "does not an issue for available devices" do
+      it "does not include an issue for available devices" do
         expect(storage.system_issues).to_not include(
           an_object_having_attributes(description: /no suitable device/)
         )

--- a/service/test/agama/storage/manager_test.rb
+++ b/service/test/agama/storage/manager_test.rb
@@ -33,6 +33,7 @@ require "agama/storage/manager"
 require "agama/storage/proposal"
 require "agama/storage/proposal_settings"
 require "agama/storage/volume"
+require "agama/dbus"
 require "y2storage/issue"
 require "y2storage/luks"
 require "yast2/fs_snapshot"
@@ -86,72 +87,6 @@ describe Agama::Storage::Manager do
   let(:security) { instance_double(Agama::Security, write: nil) }
 
   let(:scenario) { "empty-hd-50GiB.yaml" }
-
-  describe "#deprecated_system=" do
-    let(:callback) { proc {} }
-
-    context "if the current value is changed" do
-      before do
-        storage.deprecated_system = true
-      end
-
-      it "executes the on_deprecated_system_change callbacks" do
-        storage.on_deprecated_system_change(&callback)
-
-        expect(callback).to receive(:call)
-
-        storage.deprecated_system = false
-      end
-    end
-
-    context "if the current value is not changed" do
-      before do
-        storage.deprecated_system = true
-      end
-
-      it "does not execute the on_deprecated_system_change callbacks" do
-        storage.on_deprecated_system_change(&callback)
-
-        expect(callback).to_not receive(:call)
-
-        storage.deprecated_system = true
-      end
-    end
-
-    context "when the system is set as deprecated" do
-      it "marks the system as deprecated" do
-        storage.deprecated_system = true
-
-        expect(storage.deprecated_system?).to eq(true)
-      end
-
-      it "adds a deprecated system issue" do
-        expect(storage.issues).to be_empty
-
-        storage.deprecated_system = true
-
-        expect(storage.issues).to include(
-          an_object_having_attributes(description: /system devices have changed/)
-        )
-      end
-    end
-
-    context "when the system is set as not deprecated" do
-      it "marks the system as not deprecated" do
-        storage.deprecated_system = false
-
-        expect(storage.deprecated_system?).to eq(false)
-      end
-
-      it "does not add a deprecated system issue" do
-        storage.deprecated_system = false
-
-        expect(storage.issues).to_not include(
-          an_object_having_attributes(description: /system devices have changed/)
-        )
-      end
-    end
-  end
 
   describe "#probe" do
     before do

--- a/service/test/agama/storage/manager_test.rb
+++ b/service/test/agama/storage/manager_test.rb
@@ -59,7 +59,6 @@ describe Agama::Storage::Manager do
     mock_storage(devicegraph: scenario)
     allow(Agama::Storage::Proposal).to receive(:new).and_return(proposal)
     allow(Agama::HTTP::Clients::Questions).to receive(:new).and_return(questions_client)
-    allow(Agama::DBus::Clients::Software).to receive(:instance).and_return(software)
     allow(Bootloader::FinishClient).to receive(:new).and_return(bootloader_finish)
     allow(Agama::Security).to receive(:new).and_return(security)
     # mock writting config as proposal call can do storage probing, which fails in CI
@@ -79,60 +78,68 @@ describe Agama::Storage::Manager do
   let(:y2storage_manager) { Y2Storage::StorageManager.instance }
   let(:proposal) { Agama::Storage::Proposal.new(config, logger: logger) }
   let(:questions_client) { instance_double(Agama::HTTP::Clients::Questions) }
-  let(:software) do
-    instance_double(Agama::DBus::Clients::Software, selected_product: "ALP")
-  end
   let(:network) { instance_double(Agama::Network, link_resolv: nil, unlink_resolv: nil) }
   let(:bootloader_finish) { instance_double(Bootloader::FinishClient, write: nil) }
   let(:security) { instance_double(Agama::Security, write: nil) }
-
   let(:scenario) { "empty-hd-50GiB.yaml" }
+
+  describe "#activate" do
+    before do
+      allow(Agama::Storage::ISCSI::Manager).to receive(:new).and_return(iscsi)
+      allow(iscsi).to receive(:activate)
+      allow(y2storage_manager).to receive(:activate)
+    end
+
+    let(:iscsi) { Agama::Storage::ISCSI::Manager.new }
+
+    it "activates iSCSI and devices managed by Y2Storage" do
+      expect(iscsi).to receive(:activate)
+      expect(y2storage_manager).to receive(:activate) do |callbacks|
+        expect(callbacks).to be_a(Agama::Storage::Callbacks::Activate)
+      end
+      storage.activate
+    end
+
+    it "does not reset information from previous activation" do
+      expect(Y2Storage::Luks).to_not receive(:reset_activation_infos)
+      storage.activate
+    end
+  end
+
+  describe "#reset_activation" do
+    it "resets information from previous activation" do
+      expect(Y2Storage::Luks).to receive(:reset_activation_infos)
+      storage.reset_activation
+    end
+  end
 
   describe "#probe" do
     before do
       allow(Agama::Storage::ISCSI::Manager).to receive(:new).and_return(iscsi)
-      allow(y2storage_manager).to receive(:raw_probed).and_return(raw_devicegraph)
-      allow(proposal).to receive(:issues).and_return(proposal_issues)
-      allow(proposal.storage_system).to receive(:candidate_devices).and_return(devices)
       allow(proposal).to receive(:calculate_from_json).and_return(true)
       allow(proposal).to receive(:success?).and_return(true)
-      allow(proposal).to receive(:storage_json).and_return(current_config)
-      allow_any_instance_of(Agama::Storage::Configurator)
-        .to receive(:generate_configs).and_return([default_config])
-      allow(config).to receive(:pick_product)
-      allow(iscsi).to receive(:activate)
-      allow(y2storage_manager).to receive(:activate)
-      allow(iscsi).to receive(:probe)
-      allow(y2storage_manager).to receive(:probe)
+    end
+
+    let(:iscsi) { Agama::Storage::ISCSI::Manager.new }
+
+    it "probes the storage devices" do
+      expect(iscsi).to receive(:probe)
+      expect(y2storage_manager).to receive(:probe) do |callbacks|
+        expect(callbacks).to be_a(Y2Storage::Callbacks::UserProbe)
+      end
+      storage.probe
+    end
+  end
+
+  describe "#system_issues" do
+    before do
+      allow(y2storage_manager).to receive(:raw_probed).and_return(raw_devicegraph)
+      allow(proposal.storage_system).to receive(:candidate_devices).and_return(devices)
     end
 
     let(:raw_devicegraph) do
       instance_double(Y2Storage::Devicegraph, probing_issues: probing_issues)
     end
-
-    let(:proposal) { Agama::Storage::Proposal.new(config, logger: logger) }
-
-    let(:default_config) do
-      {
-        storage: {
-          drives: [
-            search: "/dev/vda1"
-          ]
-        }
-      }
-    end
-
-    let(:current_config) do
-      {
-        storage: {
-          drives: [
-            search: "/dev/vda2"
-          ]
-        }
-      }
-    end
-
-    let(:iscsi) { Agama::Storage::ISCSI::Manager.new }
 
     let(:devices) { [disk1, disk2] }
 
@@ -141,104 +148,17 @@ describe Agama::Storage::Manager do
 
     let(:probing_issues) { [Y2Storage::Issue.new("probing issue")] }
 
-    let(:proposal_issues) { [Agama::Issue.new("proposal issue")] }
-
-    let(:callback) { proc {} }
-
-    it "sets env YAST_NO_BLS_BOOT to yes if product doesn't requires bls boot explicitly" do
-      expect(config).to receive(:pick_product)
-      expect(config).to receive(:boot_strategy).and_return(nil)
-      expect(ENV).to receive(:[]=).with("YAST_NO_BLS_BOOT", "1")
-
-      storage.probe
-    end
-
-    it "probes the storage devices and calculates a proposal" do
-      expect(config).to receive(:pick_product).with("ALP")
-      expect(iscsi).to receive(:activate)
-      expect(y2storage_manager).to receive(:activate) do |callbacks|
-        expect(callbacks).to be_a(Agama::Storage::Callbacks::Activate)
-      end
-      expect(iscsi).to receive(:probe)
-      expect(y2storage_manager).to receive(:probe)
-      expect(proposal).to receive(:calculate_from_json)
-      storage.probe
-    end
-
-    it "sets the system as non deprecated" do
-      storage.deprecated_system = true
-      storage.probe
-
-      expect(storage.deprecated_system?).to eq(false)
-    end
-
-    it "adds the probing issues" do
-      storage.probe
-
-      expect(storage.issues).to include(
+    it "includes the probing issues" do
+      expect(storage.system_issues).to include(
         an_object_having_attributes(description: /probing issue/)
       )
-    end
-
-    it "adds the proposal issues" do
-      storage.probe
-
-      expect(storage.issues).to include(
-        an_object_having_attributes(description: /proposal issue/)
-      )
-    end
-
-    it "executes the on_probe callbacks" do
-      storage.on_probe(&callback)
-
-      expect(callback).to receive(:call)
-
-      storage.probe
-    end
-
-    context "if :keep_config is false" do
-      let(:keep_config) { false }
-
-      it "calculates a proposal using the default product config" do
-        expect(proposal).to receive(:calculate_from_json).with(default_config)
-        storage.probe(keep_config: keep_config)
-      end
-    end
-
-    context "if :keep_config is true" do
-      let(:keep_config) { true }
-
-      it "calculates a proposal using the current config" do
-        expect(proposal).to receive(:calculate_from_json).with(current_config)
-        storage.probe(keep_config: keep_config)
-      end
-    end
-
-    context "if :keep_activation is false" do
-      let(:keep_activation) { false }
-
-      it "resets information from previous activation" do
-        expect(Y2Storage::Luks).to receive(:reset_activation_infos)
-        storage.probe(keep_activation: keep_activation)
-      end
-    end
-
-    context "if :keep_activation is true" do
-      let(:keep_activation) { true }
-
-      it "does not reset information from previous activation" do
-        expect(Y2Storage::Luks).to_not receive(:reset_activation_infos)
-        storage.probe(keep_activation: keep_activation)
-      end
     end
 
     context "if there are available devices" do
       let(:devices) { [disk1] }
 
-      it "does not add an issue for available devices" do
-        storage.probe
-
-        expect(storage.issues).to_not include(
+      it "does not an issue for available devices" do
+        expect(storage.system_issues).to_not include(
           an_object_having_attributes(description: /no suitable device/)
         )
       end
@@ -247,10 +167,8 @@ describe Agama::Storage::Manager do
     context "if there are not available devices" do
       let(:devices) { [] }
 
-      it "adds an issue for available devices" do
-        storage.probe
-
-        expect(storage.issues).to include(
+      it "includes an issue for available devices" do
+        expect(storage.system_issues).to include(
           an_object_having_attributes(description: /no suitable device/)
         )
       end
@@ -290,8 +208,6 @@ describe Agama::Storage::Manager do
 
     let(:proposal_issues) { [Agama::Issue.new("proposal issue")] }
 
-    let(:callback) { proc {} }
-
     it "calculates a proposal using the default config if no config is given" do
       expect(proposal).to receive(:calculate_from_json).with(default_config)
       storage.configure
@@ -308,12 +224,6 @@ describe Agama::Storage::Manager do
       expect(storage.issues).to include(
         an_object_having_attributes(description: /proposal issue/)
       )
-    end
-
-    it "executes the on_configure callbacks" do
-      storage.on_configure(&callback)
-      expect(callback).to receive(:call)
-      storage.configure
     end
 
     context "if the proposal was correctly calculated" do
@@ -339,14 +249,31 @@ describe Agama::Storage::Manager do
 
   describe "#install" do
     before do
-      allow(y2storage_manager).to receive(:staging).and_return(proposed_devicegraph)
-
       allow(Yast::WFM).to receive(:CallFunction).with("inst_prepdisk", [])
       allow(Yast::WFM).to receive(:CallFunction).with("inst_bootloader", [])
-      allow(Yast::PackagesProposal).to receive(:SetResolvables)
       allow(Bootloader::ProposalClient).to receive(:new)
         .and_return(bootloader_proposal)
       allow(Y2Storage::Clients::InstPrepdisk).to receive(:new).and_return(client)
+    end
+
+    let(:bootloader_proposal) { instance_double(Bootloader::ProposalClient, make_proposal: nil) }
+    let(:client) { instance_double(Y2Storage::Clients::InstPrepdisk, run: nil) }
+
+    it "runs the inst_prepdisk client" do
+      expect(Y2Storage::Clients::InstPrepdisk).to receive(:new) do |params|
+        expect(params[:commit_callbacks]).to be_a(Agama::Storage::Callbacks::Commit)
+      end.and_return(client)
+
+      expect(client).to receive(:run)
+
+      storage.install
+    end
+  end
+
+  describe "#add_packages" do
+    before do
+      allow(y2storage_manager).to receive(:staging).and_return(proposed_devicegraph)
+      allow(Yast::PackagesProposal).to receive(:SetResolvables)
     end
 
     let(:proposed_devicegraph) do
@@ -361,26 +288,12 @@ describe Agama::Storage::Manager do
       )
     end
 
-    let(:bootloader_proposal) { instance_double(Bootloader::ProposalClient, make_proposal: nil) }
-
-    let(:client) { instance_double(Y2Storage::Clients::InstPrepdisk, run: nil) }
-
     it "adds storage software to install" do
       expect(Yast::PackagesProposal).to receive(:SetResolvables) do |_, _, packages|
         expect(packages).to contain_exactly("btrfsprogs", "snapper")
       end
 
-      storage.install
-    end
-
-    it "runs the inst_prepdisk client" do
-      expect(Y2Storage::Clients::InstPrepdisk).to receive(:new) do |params|
-        expect(params[:commit_callbacks]).to be_a(Agama::Storage::Callbacks::Commit)
-      end.and_return(client)
-
-      expect(client).to receive(:run)
-
-      storage.install
+      storage.add_packages
     end
 
     context "if iSCSI was configured" do
@@ -394,7 +307,7 @@ describe Agama::Storage::Manager do
           expect(packages).to include("open-iscsi", "iscsiuio")
         end
 
-        storage.install
+        storage.add_packages
       end
     end
 
@@ -413,7 +326,7 @@ describe Agama::Storage::Manager do
           expect(packages).to include("open-iscsi", "iscsiuio")
         end
 
-        storage.install
+        storage.add_packages
       end
     end
   end


### PR DESCRIPTION
Now only the `Agama::Issues` resulting from applying a configuration are considered as installer issues (ie. reported by the corresponding GET call, potentially raising callbacks, etc.).

The so-called `system_issues` (eg. probing errors) are now just reported at part of `#recover_system` but ignored otherwise.

Nothing was adapted in the properties of the `Agama::Issue` objects (severity, source, etc.).

**Bonus:** fixes (not related to this pull request) for the `storage-new-api` branch regarding yardoc, rubocop, unit tests, etc. 